### PR TITLE
Add DVNorthCarolina (private chat) with chat_id/api_name config support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     environment:
       - TELEGRAM_BOT_TOKEN
       - SUMMARY_API_KEY
+      - SUMMARY_ADMIN_IDS=241794132
     deploy:
       resources:
         limits:

--- a/summary-bot/README.md
+++ b/summary-bot/README.md
@@ -1,0 +1,72 @@
+# Summary Bot
+
+Telegram bot that posts daily chat summaries. It fetches a summary for each
+configured chat from the summary API and posts it back to the Telegram chat,
+either on a daily schedule or on demand via the `/summary` command.
+
+## How it works
+
+- **Scheduled** (`run_all`): once per day at `SCHEDULE_TIME`, posts a summary of
+  *yesterday* to every chat with `"scheduled": true`.
+- **On demand** (`/summary`): posts yesterday's summary to the current chat.
+  In a group this is restricted to chat admins (or operators in
+  `SUMMARY_ADMIN_IDS`); in a 1-on-1 DM with the bot anyone may run it.
+
+## `chats.json`
+
+A JSON object keyed by chat name. The **key** is used both to look up the
+Telegram chat (`@key`) and as the `chat` value sent to the summary API —
+unless overridden by the optional fields below.
+
+| Field      | Type    | Required | Description |
+|------------|---------|----------|-------------|
+| `scheduled`| boolean | yes      | Include this chat in the daily scheduled job. |
+| `chat_id`  | integer | no       | Telegram numeric chat id. Use for **private** groups/channels that have no public `@username`. When set, `@key` lookup is skipped and this id is used directly. |
+| `api_name` | string  | no       | The `chat` value sent to the summary API. Defaults to the JSON key. Use when the config key should differ from the name the summary site knows. |
+
+The two lookups are independent:
+
+- **Telegram target** → `chat_id` if present, else `@key` via `getChat`.
+- **Summary API name** → `api_name` if present, else the JSON key.
+
+### Examples
+
+Public chat — key matches both the Telegram username and the API name:
+
+```json
+"DVFinance": { "scheduled": true }
+```
+
+Private supergroup — identified by numeric id (derive from a `t.me/c/<id>/...`
+message link as `-100<id>`), API name = key:
+
+```json
+"DVNorthCarolina": { "scheduled": true, "chat_id": -1001151243206 }
+```
+
+Friendly key decoupled from both the Telegram id and the API name:
+
+```json
+"NorthCarolina": { "scheduled": true, "chat_id": -1001151243206, "api_name": "DVNorthCarolina" }
+```
+
+## Environment variables
+
+| Variable             | Required | Default                                       | Description |
+|----------------------|----------|-----------------------------------------------|-------------|
+| `TELEGRAM_BOT_TOKEN` | yes      | —                                             | Telegram Bot API token. |
+| `SUMMARY_API_KEY`    | yes      | —                                             | API key for the summary endpoint. |
+| `SUMMARY_API_URL`    | no       | `https://3gus.ru/tgscrapper/api_summary.php`  | Summary API base URL. |
+| `SUMMARY_MODEL`      | no       | `deepseek-chat`                               | Model passed to the summary API. |
+| `SCHEDULE_TIME`      | no       | `18:00`                                       | Daily run time (`HH:MM`). |
+| `SCHEDULE_TZ`        | no       | `US/Eastern`                                  | Timezone for the schedule and the "yesterday" date. |
+| `SUMMARY_ADMIN_IDS`  | no       | *(empty)*                                     | Comma/space-separated Telegram user ids allowed to run `/summary` in any chat, even when not a chat admin. |
+
+## Run
+
+```bash
+docker compose up -d summary-bot
+```
+
+Secrets (`TELEGRAM_BOT_TOKEN`, `SUMMARY_API_KEY`) are provided via the host
+environment / `.env` file referenced by `docker-compose.yml`.

--- a/summary-bot/bot.py
+++ b/summary-bot/bot.py
@@ -17,6 +17,8 @@ API_URL = os.environ.get("SUMMARY_API_URL", "https://3gus.ru/tgscrapper/api_summ
 MODEL = os.environ.get("SUMMARY_MODEL", "deepseek-chat")
 SCHEDULE_TIME = os.environ.get("SCHEDULE_TIME", "18:00")
 SCHEDULE_TZ = os.environ.get("SCHEDULE_TZ", "US/Eastern")
+# User IDs allowed to run /summary anywhere, even if not a chat admin (comma/space separated).
+ADMIN_IDS = {int(x) for x in os.environ.get("SUMMARY_ADMIN_IDS", "").replace(",", " ").split()}
 
 TG = f"https://api.telegram.org/bot{TOKEN}"
 
@@ -27,6 +29,25 @@ CHATS = list(CHATS_CONFIG.keys())
 LOCAL_TZ = pytz.timezone(SCHEDULE_TZ)
 
 last_update_id = 0
+
+
+def api_chat_name(name: str) -> str:
+    """Name sent to the summary API. Defaults to the config key, override with 'api_name'."""
+    return CHATS_CONFIG[name].get("api_name", name)
+
+
+def resolve_chat_id(name: str) -> int | None:
+    """Telegram chat_id for a configured chat: explicit 'chat_id', else @name lookup."""
+    cfg = CHATS_CONFIG[name]
+    if "chat_id" in cfg:
+        return cfg["chat_id"]
+    try:
+        r = requests.get(f"{TG}/getChat", params={"chat_id": f"@{name}"}, timeout=10)
+        if r.status_code == 200:
+            return r.json()["result"]["id"]
+    except Exception:
+        pass
+    return None
 
 
 def fetch_summary(chat: str, date: str) -> str | None:
@@ -51,6 +72,11 @@ def send_message(chat_id: int, text: str) -> None:
 def resolve_chat_name(chat_id: int) -> str | None:
     """Match a Telegram chat_id to one of the known API chat names."""
     for name in CHATS:
+        if CHATS_CONFIG[name].get("chat_id") == chat_id:
+            return name
+    for name in CHATS:
+        if "chat_id" in CHATS_CONFIG[name]:
+            continue
         try:
             r = requests.get(f"{TG}/getChat", params={"chat_id": f"@{name}"}, timeout=10)
             if r.status_code == 200 and r.json()["result"]["id"] == chat_id:
@@ -64,7 +90,7 @@ def run_for_chat(chat_id: int, chat_name: str) -> None:
     """Fetch and post summary for a single chat."""
     yesterday = (datetime.now(LOCAL_TZ) - timedelta(days=1)).strftime("%Y-%m-%d")
     log.info("Running summary for @%s date=%s", chat_name, yesterday)
-    summary = fetch_summary(chat_name, yesterday)
+    summary = fetch_summary(api_chat_name(chat_name), yesterday)
     if summary is None:
         log.info("No meaningful summary for @%s", chat_name)
         send_message(chat_id, "No summary available for yesterday.")
@@ -82,18 +108,13 @@ def run_all() -> None:
     log.info("Scheduled chats: %s", scheduled_chats)
 
     for name in scheduled_chats:
-        try:
-            r = requests.get(f"{TG}/getChat", params={"chat_id": f"@{name}"}, timeout=10)
-            if r.status_code != 200:
-                log.info("Bot not in @%s, skipping", name)
-                continue
-            chat_id = r.json()["result"]["id"]
-        except Exception:
+        chat_id = resolve_chat_id(name)
+        if chat_id is None:
             log.info("Cannot resolve @%s, skipping", name)
             continue
 
         try:
-            summary = fetch_summary(name, yesterday)
+            summary = fetch_summary(api_chat_name(name), yesterday)
             if summary is None:
                 log.info("No meaningful summary for @%s, skipping", name)
                 continue
@@ -145,7 +166,8 @@ def poll_commands() -> None:
 
         if text.startswith("/summary"):
             is_private = msg["chat"]["type"] == "private"
-            if not is_private and not is_chat_admin(chat_id, user_id):
+            is_operator = user_id in ADMIN_IDS
+            if not is_private and not is_operator and not is_chat_admin(chat_id, user_id):
                 delete_message(chat_id, msg["message_id"])
                 log.warning("Unauthorized /summary from user_id=%s in chat_id=%s, deleted", user_id, chat_id)
                 continue

--- a/summary-bot/chats.json
+++ b/summary-bot/chats.json
@@ -14,6 +14,10 @@
   "DVNewLife": {
     "scheduled": true
   },
+  "DVNorthCarolina": {
+    "scheduled": true,
+    "chat_id": -1001151243206
+  },
   "DVOfftop": {
     "scheduled": true
   },


### PR DESCRIPTION
- chats.json: support optional chat_id (numeric Telegram id for private groups without @username) and api_name (override summary API chat name)
- bot.py: resolve_chat_id/api_chat_name helpers; resolve_chat_name matches by configured chat_id first; SUMMARY_ADMIN_IDS operator allowlist for /summary outside admin status
- chats.json: add DVNorthCarolina (scheduled, chat_id -1001151243206)
- docker-compose.yml: SUMMARY_ADMIN_IDS env
- README: chats.json schema and env var docs